### PR TITLE
jieun lee / 3월 4주차 / 3문제

### DIFF
--- a/JIEUN/B2501.java
+++ b/JIEUN/B2501.java
@@ -1,0 +1,36 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class B2501 {
+    static int n, k;
+    static ArrayList<Integer> nums;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken());
+        k = Integer.parseInt(st.nextToken());
+
+        nums = new ArrayList<>();
+
+        for (int i = 1; i <= n; i++) {
+            if(n%i==0){
+                nums.add(i);
+            }
+        }
+
+        Collections.sort(nums);
+//        System.out.println(nums);
+
+        if(nums.size() < k){
+            System.out.println(0);
+        }else{
+            System.out.println(nums.get(k-1));
+        }
+
+
+    }
+}


### PR DESCRIPTION
## Info

<a href="https://www.acmicpc.net/problem/2501" rel="nofollow">2501 약수 구하기</a>

## #️⃣연관된 이슈

> #4 

## ❗ 풀이

주어진 n 만큼 for문을 돌면서 0으로 나누어 떨어지는 수는 nums에 추가하고 정렬하여 k번째로 작은 수를 출력한다.

## ❗ 추가 지식

오류 메시지인 java.lang.ArithmeticException: / by zero는 자바 프로그램이 0으로 숫자를 나누려고 시도했을 때 발생한다. 정수 나눗셈에서 0으로 나누는 것은 수학적으로 정의되지 않으므로 런타임 예외를 발생시킨다. 

## 🙂 마무리

기초 문제 뽀개기를 하고 있는데 이런 문제일 수록 범위를 대충 보기 쉬워서 틀리는 경우가 많은 것 같다.
오늘도 이거 풀면서 0으로 나누기, n 포함 안 해서 나누기 같은 실수를 해서 틀렸습니다가 계속 떴다. 
주의가 많이 필요하다!

### 스크린샷 (선택)
