### PR TITLE
jieun lee / 3월 5주차 / 2문제

### DIFF
--- a/JIEUN/B2309.java
+++ b/JIEUN/B2309.java
@@ -1,0 +1,34 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
+
+public class B2309 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int[] height = new int[9];
+        int total = 0;
+
+        for (int i = 0; i < 9; i++) {
+            height[i] = Integer.parseInt(br.readLine());
+            total += height[i];
+        }
+
+        Arrays.sort(height);
+
+        for (int i = 0; i < 9; i++) {
+            for (int j = i + 1; j < 9; j++) {
+                //전체에서 두 난쟁이의 키를 뺐을 때, 100이 되는 조합을 찾는 로직
+                if (total - height[i] - height[j] == 100) {
+                    for (int k = 0; k < 9; k++) {
+                        //진짜가 아닌 두 난쟁이를 제외하고 출력
+                        if (k == i || k == j) continue;
+                        System.out.println(height[k]);
+                    }
+                    return;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Info

<a href="https://www.acmicpc.net/problem/2309" rel="nofollow">2309 일곱 난쟁이</a>

## #️⃣연관된 이슈

> #18 

## ❗ 풀이

입력을 받아 전체 합을 만든 뒤, 두 난쟁이의 키를 뺐을 때 100이 되는 조합을 찾는다.
그리고 해당 난쟁이들을 제외하고 출력해주면 된다.

## ❗ 추가 지식

브루트 포스의 기초.

## 🙂 마무리

처음엔 스택에 넣은 후 pop 하는 과정으로 100을 만들려고 했다.
하지만 곧 브루트 포스 방식으로 돌아왔다.

### 스크린샷 (선택)
