### PR TITLE
jieun lee / 4월 1주차 / 1문제

### DIFF
--- a/JIEUN/B2693.java
+++ b/JIEUN/B2693.java
@@ -1,0 +1,28 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.Collections;
+
+public class B2693 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int tc = Integer.parseInt(br.readLine());
+
+        for (int i = 0; i < tc; i++) {
+            String [] nums = br.readLine().split(" ");
+            Integer [] num = new Integer[nums.length];
+
+            for (int j = 0; j < nums.length; j++) {
+                num[j] = Integer.parseInt(nums[j]);
+            }
+
+            //내림차순 정렬
+            Arrays.sort(num, Collections.reverseOrder());
+
+            System.out.println(num[2]); // 3번째로 큰 수 출력
+        }
+
+    }
+}


### PR DESCRIPTION
## Info

<a href="https://www.acmicpc.net/problem/2693" rel="nofollow">2693 N번째 큰 수</a>

## #️⃣연관된 이슈

> #28 

## ❗ 풀이

난 단순하게 이중 for문으로 해봤다.
이 문제를 아주 어렵게 푸는 방법으로는 priorityQueue를 활용하는 방법이 있다.

## ❗ 추가 지식

[우선 순위 큐를 활용한 방법]
최대 힙 구조를 사용하여 배열의 원소들을 넣은 뒤, 3번째로 큰 원소를 찾기 위해 n-3번 원소를 제거하고, 남은 최대 힙의 루트 노드(가장 큰 원소)를 가져오면 되는 방식으로도 풀 수 있다. 

## 🙂 마무리

쉬운 문제를 풀면 잘만 하던 알고리즘을 갑자기 어..? 이거 어떻게 했더라 하고 혼란스러워진다는 것이다.
기초 재활을 하는 이유...

### 스크린샷 (선택)
