### PR TITLE
dongheon choi / 4월 1주차 / 5문제

### DIFF
--- a/DONGHEON/[BOJ] 1931 회의실 배정
+++ b/DONGHEON/[BOJ] 1931 회의실 배정
@@ -25,7 +25,8 @@ public class boj_1931 {
 		}
 		
 	}
-	
+
+
 	public static void main(String[] args)throws IOException {
 		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
 		


### PR DESCRIPTION
## Info

<a href="https://www.acmicpc.net/problem/1931" rel="nofollow">1931 회의실 배정</a>

## #️⃣연관된 이슈

#28

## ❗ 풀이

그리드 문제이다.
회의 시간이 일찍 끝나는 순으로 정렬해서 풀어주면 된다.

## 🙂 마무리

풀이에 그냥 일찍 끝나는 순으로 정렬해서 풀어주면 된다고는 했지만 생각보다 좀더 고려해야 할 점들이 있었다.
내가 놓치고 지나간 부분들도 꽤 존재해서 많이 실패했다.

### 스크린샷 (선택)
![image](https://github.com/leeje0506/Persimmon-Algorithm-Study/assets/124031425/8c9a1508-89de-49de-821a-f07158683b6e)
