### PR TITLE
dongheon choi / 4월 2주차 / 3문제

### DIFF
--- a/DONGHEON/[BOJ] 11053 가장 긴 증가하는 부분 수열
+++ b/DONGHEON/[BOJ] 11053 가장 긴 증가하는 부분 수열
@@ -1,0 +1,45 @@
+package BOJ;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Iterator;
+import java.util.StringTokenizer;
+
+public class boj_11053 {
+
+	public static void main(String[] args)throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		
+		int N = Integer.parseInt(br.readLine());
+		
+		StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+		
+		int[] arr = new int[N];
+		
+		for(int i = 0; i < N; i++) {
+			arr[i] = Integer.parseInt(st.nextToken());
+		}
+		
+		int[] dp = new int[N];
+		for(int i = 0; i < N; i++) {
+			dp[i] = 1;
+			for(int j = 0; j < i; j++) {
+				if(arr[j] < arr[i] && dp[i] < dp[j]+1) {
+					dp[i] = dp[j] + 1;
+				}
+			}
+			
+		}
+		
+		int res = 0;
+		
+		for (int i = 0; i < N; i++) {
+			if(res < dp[i]) {
+				res = dp[i];
+			}
+		}
+		System.out.println(res);
+	}
+
+}


### PR DESCRIPTION
## Info

<a href="https://www.acmicpc.net/problem/11053" rel="nofollow">11503 가장 긴 증가하는 부분 수열</a>

## #️⃣연관된 이슈

#44 

## ❗ 풀이

DP 문제이다.


## 🙂 마무리

가장 긴 증가하는 부분 수열2 문제를 최근에 푼적이 있었다. 그 문제는 이분 탐색 문제로 지금 문제보다 더 큰 입력값들이 주어 져 있었다. 
같은 문제라도 다른 방법으로 풀어 보는 게 재밌다.  DP 방식은 풀어도 풀어도 안 익숙해 지는 건 승질난다.
이분 탐색도 그렇고 DP도 그렇고 얼른 손에 익어야하는데 ㅠㅠ
