### PR TITLE
dongheon choi / 8월 1주차 / 4문제

### DIFF
--- a/DONGHEON/[BOJ] 1052 물병
+++ b/DONGHEON/[BOJ] 1052 물병
@@ -1,0 +1,39 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+
+	public static void main(String[] args) throws IOException {
+			BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+	        StringTokenizer st = new StringTokenizer(br.readLine());
+	        int N = Integer.parseInt(st.nextToken());
+	        int K = Integer.parseInt(st.nextToken());
+
+	        int res = fn(N, K);
+	        System.out.println(res);
+	    }
+
+    private static int fn(int n, int k) {
+
+        if(n <= k) return 0;
+
+        for (int i = 0; i < k - 1; i++) {
+            int a = 0;
+            while (Math.pow(2, a) < n) {
+                a++;
+            }
+            n -= Math.pow(2, a - 1);
+
+            if(n == 0) return 0;
+        }
+
+        int a = 0;
+        while (Math.pow(2, a) < n) {
+            a++;
+        }
+        return (int) Math.pow(2, a) - n;
+    }
+}


### PR DESCRIPTION
## Info

<a href="https://www.acmicpc.net/problem/1052" rel="nofollow">1052 물병</a>

## #️⃣연관된 이슈

#203 
## ❗ 풀이

수학 문제에 가까운 문제이다. 주어진 수에 가장 가까운 2의 제곱수를 찾고 빼주면서 필요한 물병의 수를 찾아가는 문제이다.

## 🙂 마무리

몇번 봤던 문제인데 도무지 문제 이해가 되지 않던 문제였다.
직접적으로 주어지지 않는 조건은 물병을 합칠때 같은 용량의 물이 담긴 물병끼리만 합칠 수 있다.(이 조건을 직접적으로 주지 않아서 나는 문제 자체가 잘못된 문제라고 생각했다.)
그 외에도 k개 이하인 경우도 가능 하기에 이 조건도 놓치면 틀릴 수 있는 문제이다.
간만에 머리를 좀 쓰는 느낌이다.