### PR TITLE
dongheon choi / 9월 4주차 / 4문제

### DIFF
--- a/DONGHEON/[BOJ] 1976 여행 가자
+++ b/DONGHEON/[BOJ] 1976 여행 가자
@@ -1,0 +1,91 @@
+package BOJ;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.StringTokenizer;
+
+public class boj_1976_union {
+	
+	static int[] weight;
+	
+	public static void main(String[] args)throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		
+		int N = Integer.parseInt(br.readLine());
+		int M = Integer.parseInt(br.readLine());
+		
+		StringTokenizer st;
+		
+		weight = new int[N+1];
+		
+		Arrays.fill(weight, -1);
+		
+		for (int i = 1; i <= N; i++) {
+			
+			st = new StringTokenizer(br.readLine(), " ");
+			
+			for (int j = 1; j <= N; j++) {
+				
+				int connect = Integer.parseInt(st.nextToken());
+				
+				if (connect == 1) {
+					union(i , j);
+				}
+		
+			}
+			
+		}
+		
+		st = new StringTokenizer(br.readLine() , " ");
+		
+		int a = find(Integer.parseInt(st.nextToken()));
+		
+		boolean flag = true;
+		
+		for (int i = 0; i < M-1; i++) {
+			if(a != find(Integer.parseInt(st.nextToken()))) {
+				flag = false;
+				break;
+			}
+		}
+		
+		if (flag) {
+			System.out.println("YES");
+		}else {
+			System.out.println("NO");
+		}
+		
+	}
+	
+	private static int find(int x) {
+		if(weight[x] < 0) {
+			return x;
+		}else {
+			int tem = find(weight[x]);
+			weight[x] = tem;
+			return tem;
+		}
+	}
+	
+	private static void union(int x , int y) {
+		x = find(x);	
+		y = find(y);
+		
+		if (x == y) {
+			return ;
+		}
+		
+		if(weight[x] < weight[y]) {
+			weight[x] += weight[y];
+			weight[y] = x;
+		}else {
+			weight[y] += weight[x];
+			weight[x] = y;
+		}
+
+	}
+
+}


### PR DESCRIPTION
## Info

<a href="https://www.acmicpc.net/problem/1976" rel="nofollow">1976 여행가자</a>

## #️⃣연관된 이슈

#296 

## ❗ 풀이

bfs와 같은 그래프 탐색으로도 문제를 해결 할 수 있지만, 유니온 파인드를 사용하여 문제를 해결하였다.

## ❗ 추가 지식

유니온 파인드의 속도를 개선하기 위한 방법으로 find를 진행 하면서 노드를 갱신 하는 방법과 weight를 주는 방법이 존재한다.

## 🙂 마무리

예전에 풀었던 문제인데 예전에 풀었던 방법은 그래프 탐색으로 문제를 풀었었다. 이번에는 유니온 파인드를 공부하기 위해 유니온 파인드를 사용했다. 속도는 큰 차이는 없지 만 ms196 -> ms144로 개선이 되었다. 문제에서 좀 더 N이 커진다면 이 속도 차이는 좀 더 극명하게 날 것으로 보인다.