### PR TITLE
Jieun lee / 10월 4주차 / 2문제

### DIFF
--- a/JIEUN/B11947.java
+++ b/JIEUN/B11947.java
@@ -1,0 +1,74 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+
+/*
+n : 양의 정수
+F(n) : n의 각 자리 수 a에 대해서 그 수를 (9-a)로 바꾼 것
+가장 큰 자리수의 유효숫자보다 앞에 등장하는 0들은 무시한다.
+9의 반전은 0, 91의 반전은 8, 124의 반전은 875, 990의 반전은 9
+
+사랑스러움 : n * F(n)
+
+입력 : N
+출력 : 1이상 N이하인 수들의 '사랑스러움' 중 최댓값
+ */
+
+public class B11947 {
+    public static long t, n, result, a, answer, lovely;
+    public static long multiplier = 1L;
+    public static boolean Zero = false;
+    public static long max = 0L;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        t = Long.parseLong(br.readLine());
+        for (int i = 0; i < t; i++) {
+            n = Long.parseLong(br.readLine());
+            answer = Lovely(n);
+            System.out.println(answer);
+        }
+    }
+
+
+    //n의 반전을 구하는 메서드
+    public static long Banjeon(long n) {
+
+        result = 0L;
+        Zero = false;
+        multiplier = 1L;
+
+        //각 자리 수 a 구하기
+        while (n > 0) {
+            a = n % 10;
+            long reverseNumber = 9 - a;
+
+            //0이면 무시
+            if (reverseNumber != 0) {
+                Zero = true;
+            }
+
+            if (Zero) {
+                result += reverseNumber * multiplier;
+                multiplier *= 10;
+            }
+
+            n = n / 10;
+        }
+
+        return result;
+    }
+
+    //사랑스러움 구하기
+    public static long Lovely(long n) {
+        max = 0L;
+
+        for (long i = 1L; i <= n; i++) {
+            lovely = i * Banjeon(i);
+            max = Math.max(max, lovely);
+        }
+        return max;
+    }
+}

--- a/JIEUN/B11947.java
+++ b/JIEUN/B11947.java
@@ -13,13 +13,19 @@ F(n) : n의 각 자리 수 a에 대해서 그 수를 (9-a)로 바꾼 것
 
 입력 : N
 출력 : 1이상 N이하인 수들의 '사랑스러움' 중 최댓값
+
+0 ~ 9 : 사랑스러움 최댓값은 5에서 나옴 (5*4 = 20)
+10 ~ 99 : 사랑스러움 최댓값은 50에서 나옴 (50*49 = 2450)
+
+그렇다면 중간값일 때 사랑스러움 최댓값을 가질 확률이 가장 높다고 판단한다.
+=> n이 특정 자릿수 범위라면, 그 자릿수의 중간값에서 사랑스러움 최댓값이 나올 가능성이 높다.
  */
 
 public class B11947 {
-    public static long t, n, result, a, answer, lovely;
+    public static long t, n, result, a, answer, middle;
     public static long multiplier = 1L;
-    public static boolean Zero = false;
     public static long max = 0L;
+//    public static boolean Zero = false;
 
     public static void main(String[] args) throws IOException {
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
@@ -36,39 +42,66 @@ public class B11947 {
     //n의 반전을 구하는 메서드
     public static long Banjeon(long n) {
 
+        //이건 0을 미리 무시하는 방식이기 때문에 중간에 불필요하게 값을 무시하여 계산을 제대로 하지 않는 문제가 발생함.
+//        result = 0L;
+//        Zero = false;
+//        multiplier = 1L;
+//
+//        //각 자리 수 a 구하기
+//        while (n > 0) {
+//            a = n % 10;
+//            long reverseNumber = 9 - a;
+//
+//            //0이면 무시
+//            if (reverseNumber != 0) {
+//                Zero = true;
+//            }
+//
+//            if (Zero) {
+//                result += reverseNumber * multiplier;
+//                multiplier *= 10;
+//            }
+//
+//            n = n / 10;
+//        }
+
+        //자릿수가 필요한 거라서 반전을 모두 처리한 후에 최종적으로만 0 처리를 해주면 됨.
+
         result = 0L;
-        Zero = false;
         multiplier = 1L;
 
-        //각 자리 수 a 구하기
         while (n > 0) {
             a = n % 10;
             long reverseNumber = 9 - a;
-
-            //0이면 무시
-            if (reverseNumber != 0) {
-                Zero = true;
-            }
-
-            if (Zero) {
-                result += reverseNumber * multiplier;
-                multiplier *= 10;
-            }
-
-            n = n / 10;
+            result += reverseNumber * multiplier;
+            multiplier *= 10;
+            n /= 10;
         }
 
         return result;
     }
 
-    //사랑스러움 구하기
-    public static long Lovely(long n) {
-        max = 0L;
 
-        for (long i = 1L; i <= n; i++) {
-            lovely = i * Banjeon(i);
-            max = Math.max(max, lovely);
+    // 사랑스러움 : n * Banjeon(n)의 최댓값을 구하는 메서드.
+    public static long Lovely(long n) {
+        max = n * Banjeon(n);
+        middle = Middle(n);
+
+        // 중간값이 n보다 크다면, n의 자릿수 마지막 값으로 계산하도록 변경
+        if (middle > n) {
+            middle = n;  // 중간값이 n을 넘지 않도록 처리
         }
+
+        // n과 자릿수 중간값의 사랑스러움을 비교해 더 큰 값 선택
+        max = Math.max(max, middle * Banjeon(middle));
+
         return max;
+    }
+
+
+    //자릿수에 따라 중간값을 구하는 메서드
+    public static long Middle(long n) {
+        int digit = Long.toString(n).length();  // 자릿수 계산
+        return (long) Math.pow(10, digit - 1) * 5;  // 자릿수에 따른 중간값 계산
     }
 }


### PR DESCRIPTION
## Info

<a href="https://www.acmicpc.net/problem/11947" rel="nofollow">11947 이런 반전이</a>

## #️⃣연관된 이슈

> #319 

## ❗ 풀이

n : 양의 정수
F(n) : n의 각 자리 수 a에 대해서 그 수를 (9-a)로 바꾼 것
가장 큰 자리수의 유효숫자보다 앞에 등장하는 0들은 무시한다.
9의 반전은 0, 91의 반전은 8, 124의 반전은 875, 990의 반전은 9
사랑스러움 : n * F(n)

입력 : N
출력 : 1이상 N이하인 수들의 '사랑스러움' 중 최댓값

Banjeon() :  n의 반전을 구하는 메서드.
각 자리수 a 를 반전한 reverseNumber이 0이 아니라면 Zero를 true.
true인 경우 reversNumber에 10씩 곱해서 더해준다. (multiplier 시작 1)

Lovely() : n * Banjeon(n)의 최댓값을 구하는 메서드.
1이상 n이하를 돌면서 max 를 구한다. 
=> 사실 이 부분 때문에 시간초과, 메모리초과 난리 났음. 


## 🙂 마무리

이 문제는 풀기는 성공했지만, 통과를 하지는 못 했다.
이유는 시간 초과. 

n의 범위가 (1 ≤ N ≤ 1,000,000,000) 이기 때문에 배열로 저거 다 돌면 당연히 터진다.
배열을 고쳐서 해결이 될 수도 있는데, 뭔가 저 숫자의 규칙을 찾을 수 있다면 최적화 할 수 있을 거 같아서 고민을 하다가... 일단 제출하고 더 고민해보기로. 

+ 수정)

0 ~ 9 : 사랑스러움 최댓값은 5에서 나옴 (5 * 4 = 20)
10 ~ 99 : 사랑스러움 최댓값은 50에서 나옴 (50 * 49 = 2450)

그렇다면 중간값일 때 사랑스러움 최댓값을 가질 확률이 가장 높다고 판단한다.
=> n이 특정 자릿수 범위라면, 그 자릿수의 중간값에서 사랑스러움 최댓값이 나올 가능성이 높다.

Middle() : 자릿수에 따라 중간값을 찾는 메서드. 
n이 중간값보다 작다면, n이 최대.
n이 중간값과 같거나 크다면, 중간값이 최대.

Zero 는 삭제했다. 
미리 0의 처리를 해버리면 값이 다르게 들어가버리고, 계산이 틀리기 때문이다.

그래서 max = Math.max( n*반전(n) , 중간값 * 반전(중간값)) 을 비교하면 된다. 

정답 완료~!

### 스크린샷 (선택)
