### PR TITLE
Jieun lee / 11월 1주차 / 2문제

### DIFF
--- a/JIEUN/B2178_new
+++ b/JIEUN/B2178_new
@@ -1,0 +1,61 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class B2178_new {
+    static int[][] maze;
+    static int[][] distance;
+    static int n, m;
+    static int[] dx = {-1, 1, 0, 0}; // 상하좌우 방향
+    static int[] dy = {0, 0, -1, 1};
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken()); // 세로 크기
+        m = Integer.parseInt(st.nextToken()); // 가로 크기
+        
+        maze = new int[n][m];
+        distance = new int[n][m]; // 각 칸까지의 최소 거리 저장
+        
+        // 미로 입력
+        for (int i = 0; i < n; i++) {
+            String line = br.readLine();
+            for (int j = 0; j < m; j++) {
+                maze[i][j] = line.charAt(j) - '0';
+            }
+        }
+        
+        System.out.println(bfs(0, 0)); // (0, 0)에서 BFS 시작
+    }
+
+    public static int bfs(int x, int y) {
+        Queue<int[]> queue = new LinkedList<>();
+        queue.add(new int[] {x, y});
+        distance[x][y] = 1; // 시작 위치의 칸 수는 1로 설정
+
+        while (!queue.isEmpty()) {
+            int[] current = queue.poll();
+            int curX = current[0];
+            int curY = current[1];
+
+            // 상하좌우 탐색
+            for (int i = 0; i < 4; i++) {
+                int nx = curX + dx[i];
+                int ny = curY + dy[i];
+
+                // 미로 범위 내에 있으며, 이동할 수 있는 칸이고, 방문하지 않은 칸이면
+                if (nx >= 0 && ny >= 0 && nx < n && ny < m && maze[nx][ny] == 1 && distance[nx][ny] == 0) {
+                    distance[nx][ny] = distance[curX][curY] + 1; // 거리 갱신
+                    queue.add(new int[] {nx, ny});
+                }
+            }
+        }
+
+        // 목적지 (n-1, m-1)까지의 거리 반환
+        return distance[n-1][m-1];
+    }
+}


### PR DESCRIPTION
## Info

<a href="https://www.acmicpc.net/problem/2178" rel="nofollow">2178 미로 턈색</a>

## #️⃣연관된 이슈

> #338 

## ❗ 풀이

입력 :
첫 줄: N과 M (미로의 세로 크기 N, 가로 크기 M).
다음 N개의 줄: M개의 정수로 구성된 미로 배열. 1은 이동할 수 있는 칸, 0은 이동할 수 없는 칸.

출력 :
(1, 1)에서 (N, M)까지 도달하기 위해 지나야 하는 최소 칸 수.

조건 :
2 ≤ N, M ≤ 100
항상 도착 위치까지 이동할 수 있는 경우만 입력으로 주어짐.

BFS는 최단 경로를 찾기에 적합하므로, 큐를 사용하여 (1, 1)부터 BFS를 시작.
상하좌우 네 방향으로 이동하면서 이동할 수 있는 칸이 있으면 방문하고, 이전 칸의 거리 +1로 갱신.
 BFS가 종료되면 (N, M) 위치에 저장된 최소 칸 수 출력.