### PR TITLE
dongheon choi / 11월 2주차 / 1문제

### DIFF
--- a/DONGHEON/[PGS] 148652 유사 칸토어 비트열
+++ b/DONGHEON/[PGS] 148652 유사 칸토어 비트열
@@ -1,0 +1,66 @@
+import java.util.*;
+class Solution {
+    public long solution(int n, long l, long r) {
+        
+        return fn(n ,l ,r);
+    }
+    
+    private static long fn(int n, long l, long r){
+        long len = (long)Math.pow(5, n-1);
+        
+        if(n == 0){
+            return 1;
+        }
+        if( l == 1 && r == len*5){
+            return (long)Math.pow(4 , n);
+        }
+    
+        long res = 0;
+         
+        boolean left = false;  
+        
+        loop:
+        for(int i = 1; i < 6; i++){
+            
+            if(i == 3) {
+                if(!left && (i-1)*len < l && i*len >= l){
+                    if( i*len >= r ){
+                        return 0;
+                    }else{
+                        left = true;
+                        continue;
+                    }
+                }else if(i*len >= r){
+                    break loop;
+                }
+                continue;
+            }
+            
+            if(!left){
+                
+                if((i-1)*len < l && i*len >= l){
+                    
+                    if( i*len >= r ){
+                        res += fn(n-1 , l - (i-1)*len, r - (i-1)*len);
+                        break loop;
+                    }else{
+                        left = true;
+                        res += fn(n-1 , l - (i-1)*len, i*len);
+                        continue;
+                    }
+                }
+                                
+            }else if((i-1)*len < r && i*len >= r){
+                res += fn(n-1 , 1 , r - (i-1)*len);
+                break loop;
+            }else{
+                res += Math.pow(4 , n-1);
+            }
+            
+
+        }
+            
+        return res;
+        
+    }
+}


### PR DESCRIPTION
## Info

<a href="https://school.programmers.co.kr/learn/courses/30/lessons/148652" rel="nofollow">148652 유사 칸토어 비트열</a>

## #️⃣연관된 이슈

#346 

## ❗ 풀이

재귀를 이용하여 문제를 풀었다.
n 번째 비트열을 5등분 하여 1번째 2번째 4번째 5번째  파트는 n-1 번째 비트열과 동일하고 3번째 파트는 0이라는 것을 이용하여 문제를 해결했다. 
세그먼트 트리를 공부할 때 비슷하게 문제를 몇번 푼적이 있어서 그런지 푸는 방법 자체는 빠르게 떠올릴 수 있었는데 중간중간 조건들을 줘야할 것들이 많이 존재했다.

## 🙂 마무리

문제를 다풀고 다른 사람의 풀이를 보니 내가 푼 코드의 3분의 1정도의 코드들이 많았다. 그 방식은 5진법을 이용하여 문제를 푼 것들이다. 실행 시간은 내 코드가 빨랐다. 
