### PR TITLE
dongheonchoi / [힙] / 이중우선순위큐 / 골드 4

### DIFF
--- a/DONGHEON/[BOJ] 314 이중우선순위큐
+++ b/DONGHEON/[BOJ] 314 이중우선순위큐
@@ -1,0 +1,75 @@
+package BOJ;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class boj_314_이중우선순위큐 {
+
+	static Map<Integer, Integer> map;
+
+	public static void main(String[] args) throws IOException{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringBuilder sb = new StringBuilder();
+		int t = Integer.parseInt(br.readLine());
+		for(int test=0; test<t; test++) {
+			int input = Integer.parseInt(br.readLine());
+			
+			Queue<Integer> min = new PriorityQueue<>();
+			Queue<Integer> max = new PriorityQueue<>(Collections.reverseOrder()); 
+			map = new HashMap<>();
+			for(int i=0; i<input; i++) {
+				StringTokenizer st = new StringTokenizer(br.readLine());
+				String op = st.nextToken();
+				
+				if(op.equals("I")) {
+					int num = Integer.parseInt(st.nextToken());
+					max.add(num);
+					min.add(num);
+					map.put(num, map.getOrDefault(num, 0)+1);
+				}else {
+					int type = Integer.parseInt(st.nextToken());
+					
+					if(map.size()==0) continue;
+					if(type == 1) { 
+						delete(max);
+					}else { 
+						delete(min);
+					}
+				}
+			}
+			
+			if (map.size()==0) {
+	            sb.append("EMPTY\n");
+	        } else {
+	        	int res = delete(max);
+	        	sb.append(res+" ");
+	        	if(map.size()>0) res = delete(min);
+	        	sb.append(res+"\n");
+	        }
+		}
+		System.out.println(sb.toString());
+	}
+	
+	static int delete(Queue<Integer> q) {
+		int res = 0;
+		while(true) {
+			res = q.poll();
+			
+			int cnt = map.getOrDefault(res, 0);
+			if(cnt ==0) continue;
+			
+			if(cnt ==1) map.remove(res);
+			else map.put(res, cnt-1);
+			break;
+		}
+		
+		return res;
+	}
+}


### PR DESCRIPTION
## Info

<a href="https://www.acmicpc.net/problem/314" rel="nofollow">314 이중우선순위큐</a>

## #️⃣연관된 이슈

#405

## ❗ 풀이

그냥 우선순위큐 두개를 가지고 풀었더니 시간초과가 자꾸 발생하여 찾아봤더니  remove함수가 O(N)의 시간이 걸리는 것이 문제 였다. 이를 map을 사용하여 시간을 줄여주는 것이 포인트였다.


## 🙂 마무리

구글링하여 문제를 푼것이라 제대로 이해를 한것이 맞는지 잘 모르겠어서 다시한번 풀어보면서 생각을 해봐야겠다
treeMap을 이용하면 최소값 최대값을 바로 잡아낼 수 있어서 우선순위 큐를 사용하지 않고도 문제 해결이 가능했다.
treeMap에 대해 공부도 한번 해봐야겠다